### PR TITLE
Fixed two tests that were failing in different timezones, e.g. in CET.

### DIFF
--- a/spec/reality/tzoffset_spec.rb
+++ b/spec/reality/tzoffset_spec.rb
@@ -3,8 +3,8 @@ module Reality
   describe TZOffset do
     describe :initialize do
       it 'can be created from number of minutes' do
-        expect(TZOffset.new(-60).minutes).to eq(-60)
-        expect(TZOffset.new(60).minutes).to eq(60)
+        expect(TZOffset.new(-60).minutes).to eq -60
+        expect(TZOffset.new( 60).minutes).to eq 60
       end
     end
 
@@ -24,40 +24,42 @@ module Reality
     end
 
     describe :now do
-      before { allow(Time).to receive(:now).and_return(tm) }
-
-      let(:tm) { Time.new(2016, 1, 29, 14, 30, 0, '+02:00') }
-      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
-
-      subject { offset.now }
-      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
-      # its(:utc){should == tm.utc} - strange usec case
+      let(:tm){Time.new(2016, 1, 29, 14, 30, 0, '+02:00')}
+      before{
+        allow(Time).to receive(:now).and_return(tm)
+      }
+      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
+      subject{offset.now}
+      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
+      #its(:utc){should == tm.utc} - strange usec case
     end
+
 
     describe :parse do
       it 'can be created from offset str' do
-        expect(TZOffset.parse('-01:00').minutes).to eq(-60)
-        expect(TZOffset.parse('+01:00').minutes).to eq(60)
-        expect(TZOffset.parse('−01:00').minutes).to eq(-60)
-        expect(TZOffset.parse('+05:45').minutes).to eq(60 * 5 + 45)
-        expect(TZOffset.parse('UTC').minutes).to eq(0)
-        expect(TZOffset.parse('UTC+01:00').minutes).to eq(60)
-        expect(TZOffset.parse('UTC+2').minutes).to eq(120)
-        expect(TZOffset.parse('+0200').minutes).to eq(120)
+        expect(TZOffset.parse('-01:00').minutes).to eq -60
+        expect(TZOffset.parse('+01:00').minutes).to eq 60
+        expect(TZOffset.parse('−01:00').minutes).to eq -60
+        expect(TZOffset.parse('+05:45').minutes).to eq 60*5 + 45
+        expect(TZOffset.parse('UTC').minutes).to eq 0
+        expect(TZOffset.parse('UTC+01:00').minutes).to eq 60
+        expect(TZOffset.parse('UTC+2').minutes).to eq 120
+        expect(TZOffset.parse('+0200').minutes).to eq 120
       end
     end
 
+
     describe :local do
-      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
-      subject { offset.local(2016, 1, 29, 18, 15, 0) }
-      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
+      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
+      subject{offset.local(2016, 1, 29, 18, 15, 0)}
+      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
     end
 
     describe :convert do
-      let(:tm) { Time.new(2016, 1, 29, 14, 30, 0, '+02:00') }
-      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
-      subject { offset.convert(tm) }
-      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
+      let(:tm){Time.new(2016, 1, 29, 14, 30, 0, '+02:00')}
+      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
+      subject{offset.convert(tm)}
+      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
     end
   end
 end

--- a/spec/reality/tzoffset_spec.rb
+++ b/spec/reality/tzoffset_spec.rb
@@ -3,8 +3,8 @@ module Reality
   describe TZOffset do
     describe :initialize do
       it 'can be created from number of minutes' do
-        expect(TZOffset.new(-60).minutes).to eq -60
-        expect(TZOffset.new( 60).minutes).to eq 60
+        expect(TZOffset.new(-60).minutes).to eq(-60)
+        expect(TZOffset.new(60).minutes).to eq(60)
       end
     end
 
@@ -24,42 +24,40 @@ module Reality
     end
 
     describe :now do
-      let(:tm){Time.local(2016, 1, 29, 14, 30, 0, '+02:00')}
-      before{
-        allow(Time).to receive(:now).and_return(tm)
-      }
-      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
-      subject{offset.now}
-      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
-      #its(:utc){should == tm.utc} - strange usec case
-    end
+      before { allow(Time).to receive(:now).and_return(tm) }
 
+      let(:tm) { Time.new(2016, 1, 29, 14, 30, 0, '+02:00') }
+      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
+
+      subject { offset.now }
+      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
+      # its(:utc){should == tm.utc} - strange usec case
+    end
 
     describe :parse do
       it 'can be created from offset str' do
-        expect(TZOffset.parse('-01:00').minutes).to eq -60
-        expect(TZOffset.parse('+01:00').minutes).to eq 60
-        expect(TZOffset.parse('−01:00').minutes).to eq -60
-        expect(TZOffset.parse('+05:45').minutes).to eq 60*5 + 45
-        expect(TZOffset.parse('UTC').minutes).to eq 0
-        expect(TZOffset.parse('UTC+01:00').minutes).to eq 60
-        expect(TZOffset.parse('UTC+2').minutes).to eq 120
-        expect(TZOffset.parse('+0200').minutes).to eq 120
+        expect(TZOffset.parse('-01:00').minutes).to eq(-60)
+        expect(TZOffset.parse('+01:00').minutes).to eq(60)
+        expect(TZOffset.parse('−01:00').minutes).to eq(-60)
+        expect(TZOffset.parse('+05:45').minutes).to eq(60 * 5 + 45)
+        expect(TZOffset.parse('UTC').minutes).to eq(0)
+        expect(TZOffset.parse('UTC+01:00').minutes).to eq(60)
+        expect(TZOffset.parse('UTC+2').minutes).to eq(120)
+        expect(TZOffset.parse('+0200').minutes).to eq(120)
       end
     end
 
-
     describe :local do
-      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
-      subject{offset.local(2016, 1, 29, 18, 15, 0)}
-      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
+      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
+      subject { offset.local(2016, 1, 29, 18, 15, 0) }
+      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
     end
-    
+
     describe :convert do
-      let(:tm){Time.local(2016, 1, 29, 14, 30, 0, '+02:00')}
-      let(:offset){TZOffset.new(5 * 60 + 45)} # +5:45
-      subject{offset.convert(tm)}
-      it{should == Time.new(2016, 1, 29, 18, 15, 0, '+05:45')}
+      let(:tm) { Time.new(2016, 1, 29, 14, 30, 0, '+02:00') }
+      let(:offset) { TZOffset.new(5 * 60 + 45) } # +5:45
+      subject { offset.convert(tm) }
+      it { should eq Time.new(2016, 1, 29, 18, 15, 0, '+05:45') }
     end
   end
 end


### PR DESCRIPTION
I corrected two tests that were failing in `CET` and made rubocop happy with syntax.