### PR TITLE
[42] Add command line proxy for Reality entities

### DIFF
--- a/bin/really
+++ b/bin/really
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'reality'
+require 'reality/pretty_inspect'
+
+require_relative '../lib/reality/command_line'
+
+Reality.configure :demo
+
+article = ARGV.shift
+
+if "#{article}".length > 0
+  puts Reality::CommandLine.new("#{article}", ARGV).results!
+else
+  Reality::CommandLine.display_usage
+end

--- a/lib/reality/command_line.rb
+++ b/lib/reality/command_line.rb
@@ -1,0 +1,52 @@
+module Reality
+  class CommandLine
+    attr_accessor :search_term, :article, :commands, :errors
+
+    def initialize(article, commands = [])
+      self.search_term = "#{article}"
+      self.article = Reality::Entity(search_term)
+      self.errors  = []
+
+      if commands.count > 0
+        self.commands = commands.map(&:to_sym)
+      else
+        self.commands = [:describe]
+      end
+    end
+
+    def self.display_usage
+      puts "usage: really \"[search-string]\" [entity-command] [chained-command(s) ...]"
+    end
+
+    def article_found?
+      !self.article.nil?
+    end
+
+    def subcommand_for(object, subcommand)
+      if object.respond_to?(subcommand.to_sym)
+        object.send(subcommand.to_sym)
+      else
+        self.errors << "#{object} doesn't respond to #{subcommand}"
+        nil
+      end
+    end
+
+    def results!
+      return "Nothing found for: #{self.search_term}" unless self.article_found?
+      puts "Attempting entity chain: #{self.commands}" if ENV['DEBUG']
+
+      result = self.article.send(self.commands.shift)
+
+      while subcommand = self.commands.shift
+        puts "Calling #{self.article.class}##{subcommand}" if ENV['DEBUG']
+        result = subcommand_for(result, subcommand)
+      end
+
+      if errors.any?
+        "Error: #{ errors.join("\n") }"
+      else
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
#42 This adds a command line tool `really` that proxies methods to `Entity`.  I can change the name of this command to something you feel is more appropriate if necessary.

As a small example (misspelling of Seinfeld is on purpose :wink:):

<img width="817" alt="screen shot 2016-03-07 at 9 42 56 am" src="https://cloud.githubusercontent.com/assets/109135/13572818/45cb7eaa-e44a-11e5-8ab8-f4d2f1da52aa.png">