### PR TITLE
attributes alias

### DIFF
--- a/lib/reality/entity.rb
+++ b/lib/reality/entity.rb
@@ -48,6 +48,7 @@ module Reality
     #
     # @return [Hash<Symbol, Object>]
     attr_reader :values
+    alias_method :attributes, :values
 
     # @private
     attr_reader :wikipedia_type, :wikidata, :wikidata_id


### PR DESCRIPTION
Adds alias to `Entity#values` ao query like this can looks better:

```
Entity('UK').attributes.keys
```