### PR TITLE
Add timeout for List.load!

### DIFF
--- a/lib/reality/list.rb
+++ b/lib/reality/list.rb
@@ -44,16 +44,18 @@ module Reality
     # as possible. Typically, when you want to load several entities
     #
     # @return [self]
-    def load!
-      compact.partition(&:wikidata_id).tap{|wd, wp|
-          load_by_wikipedia(wp)
-          load_by_wikidata(wd)
+    def load!(frame = 3)
+      Timeout.timeout(frame) do
+        compact.partition(&:wikidata_id).tap{|wd, wp|
+            load_by_wikipedia(wp)
+            load_by_wikidata(wd)
+          }
+        # try to fallback to labels:
+        compact.reject(&:loaded?).tap{|entities|
+          load_by_wikidata_labels(entities)
         }
-      # try to fallback to labels:
-      compact.reject(&:loaded?).tap{|entities|
-        load_by_wikidata_labels(entities)
-      }
-      
+      end
+
       self
     end
 


### PR DESCRIPTION
Hi I think that `Reality::List#load!` method need a timeout mechanism. I tried to execute code:  `Reality::Entity('USA').adm_divisions.load!` and it took loots of time and didn't get result after 10 minutes. What do you think about this? 